### PR TITLE
Add test and remove binary asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# javapowerpointrgameframework
+# Java PowerPoint Game Framework
+
+This project provides a simple framework for building presentation games in PowerPoint using Java. It leverages the [Apache POI](https://poi.apache.org/) library to generate slides and draws sprites using familiar game abstractions.
+
+## Building
+
+The project uses Maven. To compile, run:
+
+```bash
+mvn package
+```
+
+Note: Maven requires network access to download dependencies on the first run.
+
+## Example Game
+
+An example is included in `src/main/java/com/example/ppgame/example/ExampleGame.java`.
+Running it will generate `game.pptx` with a short animation:
+
+```bash
+mvn exec:java -Dexec.mainClass="com.example.ppgame.example.ExampleGame"
+```
+
+This will output a PowerPoint presentation where each frame is a slide.
+
+## Running Tests
+
+The project includes a JUnit test that generates a presentation and
+verifies it can be opened. Run tests with:
+
+```bash
+mvn -q test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>ppgame</artifactId>
+    <version>0.1.0</version>
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/ppgame/example/ExampleGame.java
+++ b/src/main/java/com/example/ppgame/example/ExampleGame.java
@@ -1,0 +1,52 @@
+package com.example.ppgame.example;
+
+import com.example.ppgame.framework.Game;
+import com.example.ppgame.framework.GameObject;
+import com.example.ppgame.framework.PowerPointRenderer;
+import com.example.ppgame.framework.Sprite;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+
+import java.io.IOException;
+
+public class ExampleGame extends Game {
+    private GameObject player;
+
+    public ExampleGame(PowerPointRenderer renderer) {
+        super(renderer);
+        try {
+            Sprite sprite = new Sprite(createDummySprite(), 20, 20);
+            player = new GameObject(sprite, 50, 50);
+            addObject(player);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private byte[] createDummySprite() throws IOException {
+        BufferedImage img = new BufferedImage(20, 20, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = img.createGraphics();
+        g.setColor(Color.BLUE);
+        g.fillRect(0, 0, 20, 20);
+        g.dispose();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(img, "png", baos);
+        return baos.toByteArray();
+    }
+
+    @Override
+    protected void onUpdate(double delta) {
+        // Simple animation: move to the right
+        player.setX(player.getX() + 10 * delta);
+    }
+
+    public static void main(String[] args) throws IOException {
+        PowerPointRenderer renderer = new PowerPointRenderer();
+        ExampleGame game = new ExampleGame(renderer);
+        game.run(10); // 10 frames
+        renderer.save("game.pptx");
+    }
+}

--- a/src/main/java/com/example/ppgame/framework/Game.java
+++ b/src/main/java/com/example/ppgame/framework/Game.java
@@ -1,0 +1,40 @@
+package com.example.ppgame.framework;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class Game {
+    private final List<GameObject> objects = new ArrayList<>();
+    protected final PowerPointRenderer renderer;
+
+    public Game(PowerPointRenderer renderer) {
+        this.renderer = renderer;
+    }
+
+    public void addObject(GameObject obj) {
+        objects.add(obj);
+    }
+
+    public void run(int frames) {
+        for (int i = 0; i < frames; i++) {
+            update(1.0 / 60.0); // fixed timestep
+            draw();
+            renderer.newFrame();
+        }
+    }
+
+    private void update(double delta) {
+        onUpdate(delta);
+        for (GameObject obj : objects) {
+            obj.update(delta);
+        }
+    }
+
+    private void draw() {
+        for (GameObject obj : objects) {
+            obj.draw(renderer);
+        }
+    }
+
+    protected abstract void onUpdate(double delta);
+}

--- a/src/main/java/com/example/ppgame/framework/GameObject.java
+++ b/src/main/java/com/example/ppgame/framework/GameObject.java
@@ -1,0 +1,28 @@
+package com.example.ppgame.framework;
+
+public class GameObject {
+    protected double x;
+    protected double y;
+    protected Sprite sprite;
+
+    public GameObject(Sprite sprite, double x, double y) {
+        this.sprite = sprite;
+        this.x = x;
+        this.y = y;
+    }
+
+    public void update(double deltaTime) {
+        // Override in subclasses for custom logic
+    }
+
+    public void draw(PowerPointRenderer renderer) {
+        if (sprite != null) {
+            renderer.drawSprite(sprite, x, y);
+        }
+    }
+
+    public double getX() { return x; }
+    public double getY() { return y; }
+    public void setX(double x) { this.x = x; }
+    public void setY(double y) { this.y = y; }
+}

--- a/src/main/java/com/example/ppgame/framework/PowerPointRenderer.java
+++ b/src/main/java/com/example/ppgame/framework/PowerPointRenderer.java
@@ -1,0 +1,48 @@
+package com.example.ppgame.framework;
+
+import org.apache.poi.sl.usermodel.PictureData;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFPictureShape;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+
+import java.awt.Rectangle;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.FileOutputStream;
+
+public class PowerPointRenderer {
+    private final XMLSlideShow ppt;
+    private XSLFSlide currentSlide;
+
+    public PowerPointRenderer() {
+        ppt = new XMLSlideShow();
+        currentSlide = ppt.createSlide();
+    }
+
+    public void newFrame() {
+        currentSlide = ppt.createSlide();
+    }
+
+    public void drawSprite(Sprite sprite, double x, double y) {
+        try (InputStream is = sprite.getResourceStream();
+             ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = is.read(buffer)) != -1) {
+                bos.write(buffer, 0, len);
+            }
+            PictureData data = ppt.addPicture(bos.toByteArray(), PictureData.PictureType.PNG);
+            XSLFPictureShape shape = currentSlide.createPicture(data);
+            shape.setAnchor(new Rectangle((int)x, (int)y, sprite.getWidth(), sprite.getHeight()));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void save(String path) throws IOException {
+        try (FileOutputStream out = new FileOutputStream(path)) {
+            ppt.write(out);
+        }
+    }
+}

--- a/src/main/java/com/example/ppgame/framework/Sprite.java
+++ b/src/main/java/com/example/ppgame/framework/Sprite.java
@@ -1,0 +1,23 @@
+package com.example.ppgame.framework;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+public class Sprite {
+    private final byte[] data;
+    private final int width;
+    private final int height;
+
+    public Sprite(byte[] data, int width, int height) {
+        this.data = data;
+        this.width = width;
+        this.height = height;
+    }
+
+    public InputStream getResourceStream() {
+        return new ByteArrayInputStream(data);
+    }
+
+    public int getWidth() { return width; }
+    public int getHeight() { return height; }
+}

--- a/src/test/java/com/example/ppgame/example/ExampleGameTest.java
+++ b/src/test/java/com/example/ppgame/example/ExampleGameTest.java
@@ -1,0 +1,27 @@
+package com.example.ppgame.example;
+
+import com.example.ppgame.framework.PowerPointRenderer;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ExampleGameTest {
+    @Test
+    public void generatesValidPresentation() throws IOException {
+        System.setProperty("java.awt.headless", "true");
+        Path temp = Files.createTempFile("game", ".pptx");
+        PowerPointRenderer renderer = new PowerPointRenderer();
+        ExampleGame game = new ExampleGame(renderer);
+        game.run(2);
+        renderer.save(temp.toString());
+
+        try (XMLSlideShow slideShow = new XMLSlideShow(Files.newInputStream(temp))) {
+            assertTrue(slideShow.getSlides().size() >= 2);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- drop binary sprite asset and generate one in code
- update Sprite to load from byte array
- document running tests in README
- add JUnit test generating a PPTX and verifying slides

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684663201074832aa6c540a1ad4a9335