### PR TITLE
Add CI workflow for Maven build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,25 @@
+name: Java CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: '11'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+    - name: Upload JAR artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ppgame
+        path: target/*.jar


### PR DESCRIPTION
## Summary
- set up GitHub Actions to build the project on every push and PR
- produce JAR artifact from `target` directory

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_68497d2545dc832aaa2afef028b5c00f