### PR TITLE
Fix GitHub Action artifact version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,24 @@
+name: Maven Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: jar-artifact
+        path: target/*.jar


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build with Maven
- use `actions/upload-artifact@v4`

## Testing
- `setup_maven.sh`
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68497fe91c58832a9342675acef1a7d1